### PR TITLE
Lowercase plugin id, as is standard

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.Seren" version="0.1.04" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="0.1.04" name="Seren" provider-name="Nixgates">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0" />
 		<import addon="script.module.requests" version="2.19.1" />


### PR DESCRIPTION
As mentioned on the [Kodi wiki page on addon.xml](https://kodi.wiki/view/Addon.xml#id_attribute), the addon id "must use only lowercase characters, periods, underscores, dashes and numbers."

Also from the same page: "This identifier is also used as the name of the folder that contains the add-on", so the name of the folder, and this repo, should be lowercase as well.

Without this, Kodi cannot tell that the addon is installed via `System.HasAddon(...)`.