### PR TITLE
Foreign providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # file: ~/.gitignore
 .DS_Store
 *.idea
-*.pyo
+*.py[ocw]
 *.old
 addons_xml_generator.py

--- a/resources/lib/common/tools.py
+++ b/resources/lib/common/tools.py
@@ -468,7 +468,7 @@ def get_language_code():
         if languageCodes.isoLangs[code]['name'].lower() == language.lower():
             language_code = code
     # Continue using en until everything is tested to accept other languages
-    language_code = 'en'
+    # language_code = 'en'
     return language_code
 
 

--- a/resources/lib/modules/customProviders.py
+++ b/resources/lib/modules/customProviders.py
@@ -26,7 +26,7 @@ class providers:
         self.deploy_init()
         self.pre_update_collection = []
         # self.language = tools.getSetting('general.language')
-        self.language = 'en'
+        self.language = tools.get_language_code()
         #tools.progressDialog.create(tools.addonName, 'Please Wait, Building Provider List')
         self.known_providers = database.get_providers()
         self.known_packages = database.get_provider_packages()

--- a/resources/lib/modules/getSources.py
+++ b/resources/lib/modules/getSources.py
@@ -26,7 +26,7 @@ class Sources(tools.dialogWindow):
         self.threads = []
         self.torrentProviders = []
         self.hosterProviders = []
-        self.language = 'en'
+        self.language = tools.get_language_code()
         self.torrentCacheSources = []
         self.hosterSources = []
         self.remainingProviders = []


### PR DESCRIPTION
All this does for the time being is allow foreign providers to be used whenever Kodi's interface language is matches the provider language.

Tested with the lscrapers package, which includes both 'de' and 'pl' providers, and whenever Kodi's interface language is set to either German or Polish, Seren's provider dialogs allow to enable/disable the corresponding providers, and they function correctly when scraping. The scrapers appear to be outdated, as they pull sources, but don't actually play, however.

I'm working on trying to figure out how to get the providers to show regardless of interface language, and on splitting provider packages into their respective languages, but I wanted to open a PR here, in case anyone else sees it and wants to help.I may commit more to this branch if I find the fixes I'm looking for.