### PR TITLE
fix cloud files failing "size"

### DIFF
--- a/resources/lib/modules/sourceSelect.py
+++ b/resources/lib/modules/sourceSelect.py
@@ -27,7 +27,10 @@ def build_display_title(source):
     title = ''
 
     if source['type'] == 'torrent' or source['type'] == 'cloud':
-        size = tools.colorString(tools.source_size_display(source['size']))
+        try:
+            size = tools.colorString(tools.source_size_display(source['size']))
+        except:
+            size = 0
         title = "%s |%s %s | %s %s\n%s" % (
             quality,
             debrid_provider,


### PR DESCRIPTION
fix cloud files failing "size = tools.colorString(tools.source_size_display(source['size']))" when using source select