### PR TITLE
Use an array rather than string in keylist

### DIFF
--- a/resources/lib/modules/cacheAssist.py
+++ b/resources/lib/modules/cacheAssist.py
@@ -119,7 +119,7 @@ class CacheAssit:
                 key_list.append(str(key))
                 break
 
-        debrid.torrentSelect(torrent_id, ','.join(key_list))
+        debrid.torrentSelect(torrent_id, key_list)
         downloading_status = ['queued', 'downloading']
         current_percent = 0
         timestamp = time.time()


### PR DESCRIPTION
Using an array works better than string, however one file at a time only for some reason, I suspect it's an issue with real-debrid api. if multiple files are selected the file with the biggest ID will be downloaded.
Also, you can specify 'all' in an array and it still works - downloading all files.