### PR TITLE
Re-add labels for Debrid and Provider

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3202,3 +3202,11 @@ msgctxt "#30578"
 msgid "Invalid Trakt API keys, your authentication has been reset.\nPlease re-auth your Trakt account."
 msgstr "Invalid Trakt API keys, your authentication has been reset.\nPlease re-auth your Trakt account."
 
+msgctxt "#40233"
+msgid "Debrid"
+msgstr ""
+
+msgctxt "#40235"
+msgid "Provider"
+msgstr ""
+


### PR DESCRIPTION
Added in order to be able to reuse the 1.4.6 sources_select.xml for keeping the old source select style without having to directly label the Provider and Debrid labels.