### PR TITLE
Added Playback Ended Default Action

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.seren" version="2.0.16" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="2.0.16-PlaybackEndedDefaultAction" name="Seren" provider-name="inb4after">
     <requires>
         <import addon="xbmc.python" version="2.26.0" />
         <import addon="script.module.future" version="0.17.1"/>

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1910,8 +1910,8 @@ msgstr "Smart Play Display Style"
 
 #: \resources\settings.xml:261
 msgctxt "#30346"
-msgid "Smart Play Popup"
-msgstr "Smart Play Popup"
+msgid "Playing Next Dialog"
+msgstr "Playing Next Dialog"
 
 #: \resources\settings.xml:266
 msgctxt "#30347"
@@ -1925,8 +1925,8 @@ msgstr "Simple"
 
 #: \resources\settings.xml:267
 msgctxt "#30349"
-msgid "Default Action if Nothing Selected"
-msgstr "Default Action if Nothing Selected"
+msgid "Default Action if Playback Ended"
+msgstr "Default Action if Playback Ended"
 
 #: \resources\settings.xml:267 \resources\lib\gui\windows\source_select.py:79
 #: \resources\skins\Default\1080i\source_select.xml:352
@@ -3214,4 +3214,15 @@ msgctxt "#30581"
 msgid "Alphabetically"
 msgstr "Alphabetically"
 
+msgctxt "#30582"
+msgid "Exit Player"
+msgstr "Exit Player"
 
+#: \resources\settings.xml:261
+msgctxt "#30583"
+msgid "Smart Play"
+msgstr "Smart Play"
+
+msgctxt "#30584"
+msgid "Continue Watching"
+msgstr "Continue Watching"

--- a/resources/lib/gui/windows/playing_next.py
+++ b/resources/lib/gui/windows/playing_next.py
@@ -20,7 +20,6 @@ class PlayingNext(BaseWindow):
             self.playing_file = self.getPlayingFile()
             self.duration = self.getTotalTime() - self.getTime()
             self.closed = False
-            self.default_action = g.get_int_setting("playingnext.defaultaction")
         except:
             g.log_stacktrace()
 
@@ -123,12 +122,6 @@ class PlayingNext(BaseWindow):
                 if progress_bar is not None:
                     progress_bar.setPercent(self.calculate_percent())
 
-            if (
-                self.default_action == 1
-                and self.playing_file == self.getPlayingFile()
-                and not self.closed
-            ):
-                self.pause()
         except:
             import traceback
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -254,7 +254,12 @@
         <setting id="general.autotrynext" type="bool" label="30217" default="true"/>
         <setting id="general.resolvefailurehandling" type="enum" label="30528" lvalues="30529|30530" default="1"/>
         <setting id="general.bookmarkstyle" type="enum" label="30116" default="0" lvalues="30360|30255|30361"/>
+        
+        <!-- Smart Play -->
+        <setting type="lsep" label="30583"/>
+        <setting type="sep"/>
         <setting id="smartplay.displaystyle" type="enum" label="30345" lvalues="30193|30194" default="0"/>
+        <setting id="smartplay.defaultaction" type="enum" label="30349" default="0" lvalues="30584|30351|30582"/>
         <setting id="smartplay.playlistcreate" type="bool" label="30113" default="true"/>
         <setting id="smartplay.clickresume" type="bool" label="30114" default="false"/>
         <setting id="smartPlay.preScrape" type="bool" label="30115" default="true"/>
@@ -266,8 +271,6 @@
         <setting id="playingnext.time" type="slider" subsetting="true" label="30112" option="int" range="10,180"
                  default="30" visible="eq(-1,true)"/>
         <!--<setting id="playingnext.dialogstyle" type="enum" subsetting="true" label="30347" lvalues="30193|30348" default="0" visible="eq(-2,true)" />-->
-        <setting id="playingnext.defaultaction" type="enum" subsetting="true" label="30349" lvalues="30350|30351"
-                 default="0" visible="eq(-2,true)"/>
 
         <!-- Still Watching Dialog -->
         <setting type="lsep" label="30352"/>


### PR DESCRIPTION
This resolves #446 

This feature allows the user to continue watching / pause / exit player when playback has ended, regardless of their selection on the playing next dialog window. It also works even if playing next dialog is disabled.

Naturally, it replaces Default action if nothing selected.