### PR TITLE
fix: avoid errors on search and "Next up" with empty datasets

### DIFF
--- a/resources/lib/indexers/tvdb.py
+++ b/resources/lib/indexers/tvdb.py
@@ -931,7 +931,7 @@ class TVDBAPI(ApiBase):
         if "data" in response:
             response = response["data"]
         if not response:
-            return None
+            return []
         return response
 
     def get_json(self, url, **params):


### PR DESCRIPTION
This fixes what I've described [in this issue](https://github.com/nixgates/plugin.video.seren/issues/549#issuecomment-800674502) and probably many more similar cases.