### PR TITLE
Re-add genres to trakt_list

### DIFF
--- a/resources/lib/gui/movieMenus.py
+++ b/resources/lib/gui/movieMenus.py
@@ -402,6 +402,7 @@ class Menus:
 
         trakt_list = self.trakt.get_json_cached(
             "movies/{}".format(trakt_endpoint),
+            genres=genre_string,
             page=g.PAGE,
             extended="full"
         )

--- a/resources/lib/gui/tvshowMenus.py
+++ b/resources/lib/gui/tvshowMenus.py
@@ -515,6 +515,7 @@ class Menus:
 
         trakt_list = self.shows_database.extract_trakt_page(
             "shows/{}".format(trakt_endpoint),
+            genres=genre_string,
             page=g.PAGE,
             extended="full"
         )


### PR DESCRIPTION
Genres argument is missing in trakt_list for movies and TV shows, causing Seren to ignore any genre you select in the menu. This re-adds that argument so that the genres menu in Seren is functional again.