### PR TITLE
Change the number of thread workers from Settings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3221,3 +3221,9 @@ msgstr "Date Collected"
 msgctxt "#30581"
 msgid "Alphabetically"
 msgstr "Alphabetically"
+
+#: \resources\settings.xml:214
+msgctxt "#30582"
+msgid "Thread Workers"
+msgstr "Thread Workers"
+

--- a/resources/lib/common/thread_pool.py
+++ b/resources/lib/common/thread_pool.py
@@ -77,6 +77,7 @@ class ThreadPool:
     """
 
     def __init__(self, workers=40):
+        workers = g.get_int_setting('general.workers')
         self.limiter = g.get_global_setting("threadpool.limiter") == "true"
         self.tasks = ClearableQueue(2 * workers)
         self.stop_event = threading.Event()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -211,6 +211,7 @@
         <setting id="general.scrapedisplay" type="enum" label="30191" lvalues="30193|30194" default="0"/>
         <setting id="general.torrentCache" type="bool" label="30118" default="true"/>
         <setting id="general.timeout" type="slider" label="30120" option="int" range="10,60" default="60"/>
+        <setting id="general.workers" type="slider" label="30582" option="int" range="1,100" default="40"/>
 
         <!-- Auto Caching Assistant -->
         <setting type="lsep" label="30121"/>


### PR DESCRIPTION
In my RP3 I'm having problems with too many threads, every time you push a new update i have to change the workers from 40 to 10 in order for Seren to work...
so I'm proposing a way to control the number of workers from the Seren Settings...
