### PR TITLE
Low powered device (Firestick, Mi Box) extended scrape and pre-emptive scrape

### DIFF
--- a/resources/lib/modules/getSources.py
+++ b/resources/lib/modules/getSources.py
@@ -177,7 +177,7 @@ class Sources(object):
         """
         if g.REQUEST_PARAMS.get('action', '') == "preScrape":
             self.silent = True
-            self.timeout = 60
+            self.timeout = 240
             self._prem_terminate = lambda: False  # pylint: disable=method-hidden
 
     def _create_hoster_threads(self):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -210,7 +210,7 @@
         <setting type="sep"/>
         <setting id="general.scrapedisplay" type="enum" label="30191" lvalues="30193|30194" default="0"/>
         <setting id="general.torrentCache" type="bool" label="30118" default="true"/>
-        <setting id="general.timeout" type="slider" label="30120" option="int" range="10,60" default="60"/>
+        <setting id="general.timeout" type="slider" label="30120" option="int" range="10,180" default="60"/>
 
         <!-- Auto Caching Assistant -->
         <setting type="lsep" label="30121"/>


### PR DESCRIPTION
These two changes allow a primary scrape lasting 3 minutes and a pre-emptive scrape lasting 4 minutes (longer than you will ever need if you have disabled providers that fail altogether or providers that get hung up on CloudFlare authentication).