### PR TITLE
When retrieving videodatabase name tags from advancedsettings.xml, kodi's video db version should be appended to the end.

### DIFF
--- a/resources/lib/modules/globals.py
+++ b/resources/lib/modules/globals.py
@@ -710,7 +710,7 @@ class GlobalVariables(object):
                             elif setting.tag == 'port':
                                 result["port"] = setting.text
                             elif setting.tag == 'name':
-                                result["database"] = setting.text
+                                result["database"] = "{}{}".format(setting.text, self.get_kodi_database_version())
                             elif setting.tag == 'user':
                                 result["user"] = setting.text
                             elif setting.tag == 'pass':


### PR DESCRIPTION
When using MySQL databases via advancedsettings.xml and also specifying a name tag to override the default database name, Seren was not appending the video database version number to the name string causing a connection failure.