### PR TITLE
Increase timeout for Trakt syncs.

### DIFF
--- a/resources/lib/indexers/trakt.py
+++ b/resources/lib/indexers/trakt.py
@@ -641,7 +641,7 @@ class TraktAPI(ApiBase):
         :param params: URL params for request
         :return: request response
         """
-        timeout = params.pop("timeout", 10)
+        timeout = params.pop("timeout", 60)
         self._try_add_default_paging(params)
         self._clean_params(params)
         return self.session.get(


### PR DESCRIPTION
Seren hangs on 40% Bookmarks when pulling for people with a larger trakt connection due to the 10 second timeout.

The log is then littered with:
`2022-05-29 14:20:16.849 T:14267    INFO <general>: SEREN (-1): Failed to sync activity: Shows ratings - HTTPSConnectionPool(host='api.trakt.tv', port=443): Max retries exceeded with url: /shows/2211/seasons?extended=full%2Cepisodes (Caused by ReadTimeoutError("HTTPSConnectionPool(host='api.trakt.tv', port=443): Read timed out. (read timeout=10)"))`

Raising the timeout to 60 seconds allows for Seren to gather information for people with a larger collection.