### PR TITLE
Fix Seren not launching on Kodi 20

### DIFF
--- a/resources/lib/modules/globals.py
+++ b/resources/lib/modules/globals.py
@@ -680,12 +680,15 @@ class GlobalVariables(object):
             return MySqlConnection(config)
 
     def get_kodi_database_version(self):
+        dbids = []
         for root, dirs, files in os.walk(tools.translate_path(os.path.join("special://profile/", "Database/"))):
             for name in files:
-                dbver = re.search(r"MyVideos([^.]+)\.db", name)
+                dbver = re.search(r"MyVideos(\d+)\.db", name)
                 if dbver:
-                    return dbver.groups()[0]
-        if self.KODI_VERSION == 17:
+                    dbids.append(int(dbver.groups()[0]))
+        if dbids != []:
+            return sorted(dbids)[-1]
+        elif self.KODI_VERSION == 17:
             return "107"
         elif self.KODI_VERSION == 18:
             return "116"

--- a/resources/lib/modules/globals.py
+++ b/resources/lib/modules/globals.py
@@ -680,12 +680,19 @@ class GlobalVariables(object):
             return MySqlConnection(config)
 
     def get_kodi_database_version(self):
+        for root, dirs, files in os.walk(tools.translate_path(os.path.join("special://profile/", "Database/"))):
+            for name in files:
+                dbver = re.search(r"MyVideos([^.]+)\.db", name)
+                if dbver:
+                    return dbver.groups()[0]
         if self.KODI_VERSION == 17:
             return "107"
         elif self.KODI_VERSION == 18:
             return "116"
         elif self.KODI_VERSION == 19:
             return "119"
+        elif self.KODI_VERSION == 20:
+            return "121"
 
         raise KeyError("Unsupported kodi version")
 

--- a/resources/lib/modules/globals.py
+++ b/resources/lib/modules/globals.py
@@ -686,7 +686,7 @@ class GlobalVariables(object):
                 dbver = re.search(r"MyVideos(\d+)\.db", name)
                 if dbver:
                     dbids.append(int(dbver.groups()[0]))
-        if dbids != []:
+        if dbids:
             return sorted(dbids)[-1]
         elif self.KODI_VERSION == 17:
             return "107"


### PR DESCRIPTION
Due to the hard coding of MyVideosDB versions in Seren the addon fails to load.

The pull requests suggests we try to automatically grab the version of the db file, thus future proofing the addon and then allow fallback to the previous methodology should there be any issues.

Hard coding of Kodi 20s initial Videos DB version has also been added. 