### PR TITLE
Fixed 'info_text' item property for themes

### DIFF
--- a/resources/lib/gui/windows/__init__.py
+++ b/resources/lib/gui/windows/__init__.py
@@ -26,6 +26,17 @@ def set_info_properties(info, item):
     )
 
     item.setProperty(
+        "info_text_piped",
+        " | ".join(
+            [
+                " ".join(struct_info[c])
+                for c in codec_type_display_list
+                if struct_info[c]
+            ]
+        ),
+    )
+
+    item.setProperty(
         "info_text_formatted",
         " | ".join(
             [

--- a/resources/lib/gui/windows/__init__.py
+++ b/resources/lib/gui/windows/__init__.py
@@ -37,7 +37,7 @@ def set_info_properties(info, item):
     )
 
     item.setProperty(
-        "info_text_formatted",
+        "info_text_piped_color",
         " | ".join(
             [
                 "{}{}[/COLOR]".format(color_tag, " ".join(struct_info[c]))

--- a/resources/lib/gui/windows/__init__.py
+++ b/resources/lib/gui/windows/__init__.py
@@ -16,7 +16,7 @@ def set_info_properties(info, item):
 
     item.setProperty(
         "info_text",
-        " | ".join(
+        " ".join(
             [
                 " ".join(struct_info[c])
                 for c in codec_type_display_list

--- a/resources/skins/Default/1080i/manual_caching.xml
+++ b/resources/skins/Default/1080i/manual_caching.xml
@@ -159,8 +159,8 @@
 									<align>right</align>
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
-									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_formatted)][/UPPERCASE]</label>
-									<visible>!String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_piped_color)][/UPPERCASE]</label>
+									<visible>!String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 								
 								<!-- Resolution -->
@@ -170,7 +170,7 @@
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
 									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR]</label>
-									<visible>String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<visible>String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 							</control>
 						</control>
@@ -262,8 +262,8 @@
 									<align>right</align>
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
-									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_formatted)][/UPPERCASE]</label>
-									<visible>!String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_piped_color)][/UPPERCASE]</label>
+									<visible>!String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 								
 								<!-- Resolution -->
@@ -273,7 +273,7 @@
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
 									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR]</label>
-									<visible>String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<visible>String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 							</control>
 						</control>
@@ -404,7 +404,7 @@
 							<font>font12</font>
 							<align>right</align>
 							<textcolor>FFFFFFFF</textcolor>
-							<label>[B][UPPERCASE]$INFO[ListItem.Property(info_text_formatted)][/UPPERCASE][/B]</label>
+							<label>[B][UPPERCASE]$INFO[ListItem.Property(info_text_piped_color)][/UPPERCASE][/B]</label>
 						</control>
                     </control>
                 </control>

--- a/resources/skins/Default/1080i/resolver.xml
+++ b/resources/skins/Default/1080i/resolver.xml
@@ -191,7 +191,7 @@
 					<font>font12</font>
 					<align>right</align>
 					<textcolor>FFFFFFFF</textcolor>
-					<label>[B][UPPERCASE]$INFO[Window().Property(info_text_formatted)][/UPPERCASE][/B]</label>
+					<label>[B][UPPERCASE]$INFO[Window().Property(info_text_piped_color)][/UPPERCASE][/B]</label>
 				</control>
 			</control>
 		</control>

--- a/resources/skins/Default/1080i/source_select.xml
+++ b/resources/skins/Default/1080i/source_select.xml
@@ -163,8 +163,8 @@
 									<align>right</align>
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
-									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_formatted)][/UPPERCASE]</label>
-									<visible>!String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_piped_color)][/UPPERCASE]</label>
+									<visible>!String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 								
 								<!-- Resolution -->
@@ -174,7 +174,7 @@
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
 									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR][/UPPERCASE]</label>
-									<visible>String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<visible>String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 							</control>
 						</control>
@@ -266,8 +266,8 @@
 									<align>right</align>
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
-									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_formatted)][/UPPERCASE]</label>
-									<visible>!String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR] | $INFO[ListItem.Property(info_text_piped_color)][/UPPERCASE]</label>
+									<visible>!String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 								
 								<!-- Resolution -->
@@ -277,7 +277,7 @@
 									<height>20</height>
 									<textcolor>66FFFFFF</textcolor>
 									<label>[UPPERCASE][COLOR $INFO[Window().Property(settings.color)]]$INFO[ListItem.Property(quality)][/COLOR][/UPPERCASE]</label>
-									<visible>String.IsEmpty(ListItem.Property(info_text_formatted))</visible>
+									<visible>String.IsEmpty(ListItem.Property(info_text_piped_color))</visible>
 								</control>
 							</control>
 						</control>
@@ -408,7 +408,7 @@
 							<font>font12</font>
 							<align>right</align>
 							<textcolor>FFFFFFFF</textcolor>
-							<label>[B][UPPERCASE]$INFO[ListItem.Property(info_text_formatted)][/UPPERCASE][/B]</label>
+							<label>[B][UPPERCASE]$INFO[ListItem.Property(info_text_piped_color)][/UPPERCASE][/B]</label>
 						</control>
                     </control>
                 </control>


### PR DESCRIPTION
This fixes #783 