### PR TITLE
Update to Include RD/AD workaround and various other changes/fixes

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.seren" version="3.0.1" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="3.0.5" name="Seren" provider-name="Nixgates">
     <requires>
         <import addon="xbmc.addon" version="17.9.910" />
         <import addon="xbmc.python" version="3.0.0" />
@@ -65,6 +65,15 @@
             <screenshot>resources/screenshots/screenshot-04.jpg</screenshot>
         </assets>
         <news>
+            Changelog 3.0.5
+            [BUG] Fix RD playback
+            [BUG] Improved 3D Filtering
+            [FEATURE] Added option to filer results by internet speed
+            [FEATURE] Added 'Cancel' button to smartplay window
+            [FEATURE] Added 'Icon Only' scraper display style option
+            [FEATURE] Added option to hide resolver window when attempting to play
+            [FEATURE] Added 60 FPS filter
+
             Changelog 3.0.1
             [FEATURE] Handle Kodi database version for Omega 21
 

--- a/addon.xml
+++ b/addon.xml
@@ -9,6 +9,7 @@
         <import addon="script.module.inputstreamhelper" version="0.5.10" optional="true"/>
         <import addon="script.module.unidecode" version="1.1.1"/>
         <import addon="script.module.myconnpy" version="8.0.18"/>
+        <import addon="script.module.web-pdb" version="1.5.6"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="seren.py">
         <provides>video</provides>
@@ -68,6 +69,8 @@
             Changelog 3.0.62
             [BUG] Optimised RD fix implementation
             [BUG] Improved RD season pack handling
+            [BUG] Improved RD download handling when uncached
+            [BUG] Improved RD file selection handling when uncached
 
             Changelog 3.0.61
             [BUG] Fix AD not deleting magnet if not cached

--- a/addon.xml
+++ b/addon.xml
@@ -27,7 +27,7 @@
         <website>https://github.com/nixgates/plugin.video.seren</website>
         <source>https://github.com/nixgates/plugin.video.seren</source>
         <disclaimer lang="en">
-            Last updated: November 14, 2024.
+            Last updated: November 25, 2024.
             The information contained within the Seren software (the "Service") is for general information purposes
             only.
             The author assumes no responsibility for errors, omissions in the contents on the Service, nor does it
@@ -71,6 +71,7 @@
             [FEATURE] Added option to filer results by internet speed
             [FEATURE] Added 'Cancel' button to smartplay window
             [FEATURE] Added 'Icon Only' scraper display style option
+            [FEATURE] Added 'Minimum Percentage Left Before Showing Dialog option' for smartplay window
             [FEATURE] Added option to hide resolver window when attempting to play
             [FEATURE] Added 60 FPS filter
 

--- a/addon.xml
+++ b/addon.xml
@@ -9,7 +9,6 @@
         <import addon="script.module.inputstreamhelper" version="0.5.10" optional="true"/>
         <import addon="script.module.unidecode" version="1.1.1"/>
         <import addon="script.module.myconnpy" version="8.0.18"/>
-        <import addon="script.module.web-pdb" version="1.5.6"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="seren.py">
         <provides>video</provides>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.seren" version="3.0.61" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="3.0.62" name="Seren" provider-name="Nixgates">
     <requires>
         <import addon="xbmc.addon" version="17.9.910" />
         <import addon="xbmc.python" version="3.0.0" />
@@ -27,7 +27,7 @@
         <website>https://github.com/nixgates/plugin.video.seren</website>
         <source>https://github.com/nixgates/plugin.video.seren</source>
         <disclaimer lang="en">
-            Last updated: November 26, 2024.
+            Last updated: November 29, 2024.
             The information contained within the Seren software (the "Service") is for general information purposes
             only.
             The author assumes no responsibility for errors, omissions in the contents on the Service, nor does it
@@ -65,6 +65,10 @@
             <screenshot>resources/screenshots/screenshot-04.jpg</screenshot>
         </assets>
         <news>
+            Changelog 3.0.62
+            [BUG] Optimised RD fix implementation
+            [BUG] Improved RD season pack handling
+
             Changelog 3.0.61
             [BUG] Fix AD not deleting magnet if not cached
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.seren" version="3.0.6" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="3.0.61" name="Seren" provider-name="Nixgates">
     <requires>
         <import addon="xbmc.addon" version="17.9.910" />
         <import addon="xbmc.python" version="3.0.0" />
@@ -65,6 +65,9 @@
             <screenshot>resources/screenshots/screenshot-04.jpg</screenshot>
         </assets>
         <news>
+            Changelog 3.0.61
+            [BUG] Fix AD not deleting magnet if not cached
+
             Changelog 3.0.6
             [BUG] Fix AD Playback
             

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.seren" version="3.0.5" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="3.0.6" name="Seren" provider-name="Nixgates">
     <requires>
         <import addon="xbmc.addon" version="17.9.910" />
         <import addon="xbmc.python" version="3.0.0" />
@@ -27,7 +27,7 @@
         <website>https://github.com/nixgates/plugin.video.seren</website>
         <source>https://github.com/nixgates/plugin.video.seren</source>
         <disclaimer lang="en">
-            Last updated: November 25, 2024.
+            Last updated: November 26, 2024.
             The information contained within the Seren software (the "Service") is for general information purposes
             only.
             The author assumes no responsibility for errors, omissions in the contents on the Service, nor does it
@@ -65,6 +65,9 @@
             <screenshot>resources/screenshots/screenshot-04.jpg</screenshot>
         </assets>
         <news>
+            Changelog 3.0.6
+            [BUG] Fix AD Playback
+            
             Changelog 3.0.5
             [BUG] Fix RD playback
             [BUG] Improved 3D Filtering

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changelog 3.0.6
+[BUG] Fix AD Playback
+
 Changelog 3.0.5
 [BUG] Fix RD playback
 [BUG] Improved 3D Filtering

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changelog 3.0.61
+[BUG] Fix AD not deleting magnet if not cached
+
 Changelog 3.0.6
 [BUG] Fix AD Playback
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+Changelog 3.0.5
+[BUG] Fix RD playback
+[BUG] Improved 3D Filtering
+[FEATURE] Added option to filer results by internet speed
+[FEATURE] Added 'Cancel' button to smartplay window
+[FEATURE] Added 'Icon Only' scraper display style option
+[FEATURE] Added option to hide resolver window when attempting to play
+[FEATURE] Added 60 FPS filter
+
 Changelog 3.0.1
 [FEATURE] Handle Kodi database version for Omega 21
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 Changelog 3.0.62
 [BUG] Optimised RD fix implementation
 [BUG] Improved RD season pack handling
+[BUG] Improved RD download handling when uncached
+[BUG] Improved RD file selection handling when uncached
 
 Changelog 3.0.61
 [BUG] Fix AD not deleting magnet if not cached

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Changelog 3.0.62
+[BUG] Optimised RD fix implementation
+[BUG] Improved RD season pack handling
+
 Changelog 3.0.61
 [BUG] Fix AD not deleting magnet if not cached
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Changelog 3.0.5
 [FEATURE] Added option to filer results by internet speed
 [FEATURE] Added 'Cancel' button to smartplay window
 [FEATURE] Added 'Icon Only' scraper display style option
+[FEATURE] Added 'Minimum Percentage Left Before Showing Dialog option' for smartplay window
 [FEATURE] Added option to hide resolver window when attempting to play
 [FEATURE] Added 60 FPS filter
 

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -3671,3 +3671,43 @@ msgstr "عذرا، مصادر نوع {} غير متوفرة للتنزيل"
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "البذور"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "استخدام سرعة الإنترنت"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "سرعة التنزيل (ميجابت/ثانية)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "استخدم الحجم الأقصى"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "عن"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "السرعة الدنيا (ميجابت/ثانية)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "إخفاء نافذة الحل"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "الحد الأدنى للنسبة المتبقية قبل إظهار الحوار"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "أيقونة فقط"

--- a/resources/language/resource.language.da_DK/strings.po
+++ b/resources/language/resource.language.da_DK/strings.po
@@ -3667,3 +3667,43 @@ msgstr "Beklager, {} type kilder er ikke tilgængelige til download"
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Frø"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Brug internethastighed"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Downloadhastighed (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Brug Max Size"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Slukket"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Min. hastighed (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Skjul Resolver-vindue"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Mindste procentdel tilbage før visning af dialog"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Kun ikon"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -3718,3 +3718,43 @@ msgstr "Leider stehen Quellen vom Typ {} nicht zum Download zur Verfügung."
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Seeds"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Nutzen Sie Internetgeschwindigkeit"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Download-Geschwindigkeit (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Verwenden Sie die maximale Größe"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Aus"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Mindestgeschwindigkeit (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Resolver-Fenster ausblenden"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Mindestprozentsatz, der vor der Anzeige des Dialogs verbleibt"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Nur Symbol"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -3718,3 +3718,43 @@ msgstr "Λυπούμαστε, οι πηγές τύπου {} δεν είναι δ
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Για σπορά"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Χρησιμοποιήστε την Ταχύτητα Διαδικτύου"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Ταχύτητα λήψης (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Χρησιμοποιήστε μέγιστο μέγεθος"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Μακριά από"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Ελάχιστη ταχύτητα (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Απόκρυψη παραθύρου επίλυσης"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Ελάχιστο ποσοστό που απομένει πριν από την εμφάνιση του διαλόγου"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Μόνο εικονίδιο"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -3661,3 +3661,43 @@ msgstr "Sorry, {} type sources are not available for downloading"
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Seeds"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Use Internet Speed"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Download Speed (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Use Max Size"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Off"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Min Speed (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Hide Resolver Window"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Minimum Percentage Left Before Showing Dialog"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Icon Only"

--- a/resources/language/resource.language.es_ES/strings.po
+++ b/resources/language/resource.language.es_ES/strings.po
@@ -3701,8 +3701,7 @@ msgstr "Descarga finalizada: {}"
 #: /resources/lib/gui/windows/source_select.py:56
 msgctxt "#30641"
 msgid "Sorry, {} type sources are not available for downloading"
-msgstr ""
-"Lo sentimos, los orígenes de tipo {} no están disponibles para descargar"
+msgstr "Lo sentimos, los orígenes de tipo {} no están disponibles para descargar"
 
 #: /resources/skins/Default/1080i/manual_caching.xml:125
 #: /resources/skins/Default/1080i/manual_caching.xml:238
@@ -3710,3 +3709,43 @@ msgstr ""
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Semillas"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Usar velocidad de Internet"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Velocidad de descarga (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Usar tamaño máximo"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Apagado"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Velocidad mínima (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Ocultar ventana de resolución"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Porcentaje mínimo restante antes de mostrar el cuadro de diálogo"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Sólo icono"

--- a/resources/language/resource.language.es_MX/strings.po
+++ b/resources/language/resource.language.es_MX/strings.po
@@ -3701,8 +3701,7 @@ msgstr "Descarga finalizada: {}"
 #: /resources/lib/gui/windows/source_select.py:56
 msgctxt "#30641"
 msgid "Sorry, {} type sources are not available for downloading"
-msgstr ""
-"Lo sentimos, los orígenes de tipo {} no están disponibles para descargar"
+msgstr "Lo sentimos, los orígenes de tipo {} no están disponibles para descargar"
 
 #: /resources/skins/Default/1080i/manual_caching.xml:125
 #: /resources/skins/Default/1080i/manual_caching.xml:238
@@ -3710,3 +3709,43 @@ msgstr ""
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Semillas"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Usar velocidad de Internet"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Velocidad de descarga (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Usar tamaño máximo"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Apagado"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Velocidad mínima (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Ocultar ventana de resolución"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Porcentaje mínimo restante antes de mostrar el cuadro de diálogo"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Sólo icono"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -3709,3 +3709,43 @@ msgstr ""
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Graines"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Utiliser la vitesse Internet"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Vitesse de téléchargement (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Utiliser la taille maximale"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Désactivé"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Vitesse minimale (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Masquer la fenêtre du résolveur"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Pourcentage minimum restant avant d'afficher la boîte de dialogue"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Icône uniquement"

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -3613,3 +3613,43 @@ msgstr "מצטערים, מקורות מסוג {} אינם זמינים להור�
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "זרעים"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "השתמש במהירות האינטרנט"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "מהירות הורדה (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "השתמש בגודל מקסימלי"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "כבוי"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "מהירות מינימלית (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "הסתר חלון פותר"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "האחוז המינימלי שנותר לפני הצגת דו-שיח"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "סמל בלבד"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -3704,3 +3704,43 @@ msgstr ""
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Sementi"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Utilizza la velocità di Internet"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Velocità di download (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Usa dimensione massima"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Spento"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Velocità minima (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Nascondi la finestra del risolutore"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Percentuale minima rimasta prima della visualizzazione della finestra di dialogo"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Solo icona"

--- a/resources/language/resource.language.nl_NL/strings.po
+++ b/resources/language/resource.language.nl_NL/strings.po
@@ -3701,3 +3701,43 @@ msgstr "Sorry, {} type bronnen zijn niet beschikbaar voor downloaden"
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Zaden"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Gebruik internetsnelheid"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Downloadsnelheid (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Gebruik maximale grootte"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Uit"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Min. snelheid (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Oplosservenster verbergen"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Minimumpercentage resterend voordat dialoogvenster wordt weergegeven"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Alleen pictogram"

--- a/resources/language/resource.language.pl_PL/strings.po
+++ b/resources/language/resource.language.pl_PL/strings.po
@@ -3696,3 +3696,43 @@ msgstr "Przepraszamy, źródła typu {} nie są dostępne do pobrania"
 msgctxt "#30486"
 msgid "Seeds"
 msgstr "Nasiona"
+
+#: /resources/settings.xml:1491
+msgctxt "#30645"
+msgid "Use Internet Speed"
+msgstr "Użyj szybkości Internetu"
+
+#: /resources/settings.xml:1565
+msgctxt "#30646"
+msgid "Download Speed (Mbit/s)"
+msgstr "Prędkość pobierania (Mbit/s)"
+
+#: /resources/settings.xml:1492
+msgctxt "#30647"
+msgid "Use Max Size"
+msgstr "Użyj maksymalnego rozmiaru"
+
+#: /resources/settings.xml:1490
+msgctxt "#30648"
+msgid "Off"
+msgstr "Wyłączony"
+
+#: /resources/settings.xml:1582
+msgctxt "#30649"
+msgid "Min Speed (Mbit/s)"
+msgstr "Minimalna prędkość (Mbit/s)"
+
+#: /resources/settings.xml:1236
+msgctxt "#30650"
+msgid "Hide Resolver Window"
+msgstr "Ukryj okno programu do rozpoznawania nazw"
+
+#: /resources/settings.xml:2054
+msgctxt "#30651"
+msgid "Minimum Percentage Left Before Showing Dialog"
+msgstr "Minimalny procent pozostały przed wyświetleniem okna dialogowego"
+
+#: /resources/settings.xml:1231
+msgctxt "#30652"
+msgid "Icon Only"
+msgstr "Tylko ikona"

--- a/resources/lib/common/source_utils.py
+++ b/resources/lib/common/source_utils.py
@@ -104,6 +104,7 @@ INFO_STRUCT = {
         "HC",
         "SCR",
         "3D",
+        "60-FPS"
     },
 }
 
@@ -206,7 +207,8 @@ INFO_TYPES = {
         "vostfr",
         "vo stfr",
     ],
-    "3D": [" 3d"],
+    "3D": [" 3d", " half ou", " half sbs"],
+    "60-FPS": [" 60 fps", " 60fps"]
 }
 
 

--- a/resources/lib/debrid/all_debrid.py
+++ b/resources/lib/debrid/all_debrid.py
@@ -155,9 +155,6 @@ class AllDebrid:
             g.set_setting("alldebrid.username", user_information["username"])
             g.set_setting("alldebrid.premiumstatus", self.get_account_status().title())
 
-    def check_hash(self, hash_list):
-        return self.post_json("magnet/instant", {"magnets[]": hash_list})
-
     def upload_magnet(self, magnet_hash):
         return self.get_json("magnet/upload", magnet=magnet_hash)
 

--- a/resources/lib/debrid/real_debrid.py
+++ b/resources/lib/debrid/real_debrid.py
@@ -254,9 +254,12 @@ class RealDebrid:
         self.torrent_select_all(torrent_id)
         torrent_info = self.torrent_info(torrent_id)
 
+        if "files" in torrent_info:
+            torrent_info["files"] = [file for file in torrent_info["files"] if 'sample' not in file['path'].lower() and source_utils.is_file_ext_valid(file["path"])]
+
         if torrent_info.get('status') == 'downloaded':
             hash_dict = {
-                hash_value: {"torrent_id": torrent_id,'rd': [
+                hash_value: {"torrent_id": torrent_id, "torrent_info": torrent_info, 'rd': [
                     {str(file['id']): {'filename': file['path'], 'filesize': file['bytes']}}
                     for file in torrent_info.get('files', []) if file.get('selected') == 1
                 ]}

--- a/resources/lib/debrid/real_debrid.py
+++ b/resources/lib/debrid/real_debrid.py
@@ -12,6 +12,7 @@ from resources.lib.modules.exceptions import RanOnceAlready
 from resources.lib.modules.exceptions import UnexpectedResponse
 from resources.lib.modules.global_lock import GlobalLock
 from resources.lib.modules.globals import g
+import os
 
 RD_AUTH_KEY = "rd.auth"
 RD_STATUS_KEY = "rd.premiumstatus"
@@ -242,20 +243,64 @@ class RealDebrid:
             return response.json()
         except (ValueError, AttributeError):
             return response
-
+        
     def check_hash(self, hash_list):
         if isinstance(hash_list, list):
             hash_list = [hash_list[x : x + 100] for x in range(0, len(hash_list), 100)]
-            ThreadPool().map_results(self._check_hash_thread, ((sorted(section),) for section in hash_list))
+            thread = ThreadPool()
+            for section in hash_list:
+                thread.put(self._check_hash_thread, sorted(section))
+            thread.wait_completion()
             return self.cache_check_results
         else:
-            hash_string = f"/{hash_list}"
-            return self.get_url(f"torrents/instantAvailability{hash_string}")
+            magnet = 'magnet:?xt=urn:btih:' + hash_list
+            response = self.add_magnet(magnet)
+            try: torr_id = response['id']
+            except: return {}
+            response = self.torrent_select_all(torr_id)
+            response = self.torrent_info(torr_id)
+            if response['status'] == 'downloaded':
+                hash_dict = {hash_list: {'rd':[]}}
+                for x in response['files']:
+                    if x['selected'] == 1:
+                        hash_dict[hash_list]['rd'].append({str(x['id']):{'filename':x['path'],'filesize':x['bytes']}})
+                response = self.delete_torrent(torr_id)
+                return hash_dict
+            else:
+                response = self.delete_torrent(torr_id)
+                return {}
 
     def _check_hash_thread(self, hashes):
-        hash_string = f"/{'/'.join(hashes)}"
-        response = self.get_url(f"torrents/instantAvailability{hash_string}")
-        self.cache_check_results.update(response)
+        for i in hashes:
+            magnet = 'magnet:?xt=urn:btih:' + i
+            response = self.add_magnet(magnet)
+            try: torr_id = response['id']
+            except: continue
+            response = self.torrent_select_all(torr_id)
+            response = self.torrent_info(torr_id)
+            if response['status'] == 'downloaded':
+                hash_dict = {i: {'rd':[]}}
+                for x in response['files']:
+                    if x['selected'] == 1:
+                        hash_dict[i]['rd'].append({str(x['id']):{'filename':x['path'],'filesize':x['bytes']}})
+                response = self.delete_torrent(torr_id)
+                self.cache_check_results.update(hash_dict)
+            else:
+                response = self.delete_torrent(torr_id)
+
+    def torrent_select_all(self, torrent_id):
+        torr_info = self.torrent_info(torrent_id)
+        file_string = ''
+        for i in torr_info['files']:
+            res = [ele for ele in self.common_video_extensions() if(ele in os.path.splitext(i['path'])[1])]
+            if res and ('Sample' in i['path'] or 'sample.' in i['path']) == False:
+                if file_string == '':
+                    file_string = file_string + str(i['id'])
+                else:
+                    file_string = file_string + ',' + str(i['id'])
+        file_id='all'
+        response = self.torrent_select(torrent_id,file_string)
+        return response
 
     def add_magnet(self, magnet):
         post_data = {"magnet": magnet}
@@ -287,6 +332,14 @@ class RealDebrid:
     def delete_torrent(self, id):
         url = f"torrents/delete/{id}"
         self.delete_url(url)
+
+    def common_video_extensions(self):
+        getSupportedMedia = '.m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.xspf|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.mpl|.webm|.bdmv|.bdm|.wtv|.trp|.f4v|.ssif|.pvr|.disc|'
+        return [
+            i
+            for i in getSupportedMedia.split("|")
+            if i not in ["", ".zip", ".rar"]
+        ]
 
     @staticmethod
     def is_streamable_storage_type(storage_variant):

--- a/resources/lib/debrid/real_debrid.py
+++ b/resources/lib/debrid/real_debrid.py
@@ -264,6 +264,9 @@ class RealDebrid:
                     for file in torrent_info.get('files', []) if file.get('selected') == 1
                 ]}
             }
+
+            if g.get_bool_setting("rd.autodelete"):
+                self.delete_torrent(torrent_id)
         else:
             self.delete_torrent(torrent_id)
             hash_dict = {}

--- a/resources/lib/debrid/real_debrid.py
+++ b/resources/lib/debrid/real_debrid.py
@@ -6,7 +6,6 @@ import xbmcgui
 
 from resources.lib.common import source_utils
 from resources.lib.common import tools
-from resources.lib.common.thread_pool import ThreadPool
 from resources.lib.database.cache import use_cache
 from resources.lib.modules.exceptions import RanOnceAlready
 from resources.lib.modules.exceptions import UnexpectedResponse
@@ -244,63 +243,50 @@ class RealDebrid:
         except (ValueError, AttributeError):
             return response
         
-    def check_hash(self, hash_list):
-        if isinstance(hash_list, list):
-            hash_list = [hash_list[x : x + 100] for x in range(0, len(hash_list), 100)]
-            thread = ThreadPool()
-            for section in hash_list:
-                thread.put(self._check_hash_thread, sorted(section))
-            thread.wait_completion()
-            return self.cache_check_results
-        else:
-            magnet = 'magnet:?xt=urn:btih:' + hash_list
-            response = self.add_magnet(magnet)
-            try: torr_id = response['id']
-            except: return {}
-            response = self.torrent_select_all(torr_id)
-            response = self.torrent_info(torr_id)
-            if response['status'] == 'downloaded':
-                hash_dict = {hash_list: {'rd':[]}}
-                for x in response['files']:
-                    if x['selected'] == 1:
-                        hash_dict[hash_list]['rd'].append({str(x['id']):{'filename':x['path'],'filesize':x['bytes']}})
-                response = self.delete_torrent(torr_id)
-                return hash_dict
-            else:
-                response = self.delete_torrent(torr_id)
-                return {}
+    def check_hash(self, hash_value):
+        magnet = f'magnet:?xt=urn:btih:{hash_value}'
+        response = self.add_magnet(magnet)
 
-    def _check_hash_thread(self, hashes):
-        for i in hashes:
-            magnet = 'magnet:?xt=urn:btih:' + i
-            response = self.add_magnet(magnet)
-            try: torr_id = response['id']
-            except: continue
-            response = self.torrent_select_all(torr_id)
-            response = self.torrent_info(torr_id)
-            if response['status'] == 'downloaded':
-                hash_dict = {i: {'rd':[]}}
-                for x in response['files']:
-                    if x['selected'] == 1:
-                        hash_dict[i]['rd'].append({str(x['id']):{'filename':x['path'],'filesize':x['bytes']}})
-                response = self.delete_torrent(torr_id)
-                self.cache_check_results.update(hash_dict)
-            else:
-                response = self.delete_torrent(torr_id)
+        if 'id' not in response:
+            return {}
+
+        torrent_id = response['id']
+        self.torrent_select_all(torrent_id)
+        torrent_info = self.torrent_info(torrent_id)
+
+        if torrent_info.get('status') == 'downloaded':
+            hash_dict = {
+                hash_value: {"torrent_id": torrent_id,'rd': [
+                    {str(file['id']): {'filename': file['path'], 'filesize': file['bytes']}}
+                    for file in torrent_info.get('files', []) if file.get('selected') == 1
+                ]}
+            }
+        else:
+            self.delete_torrent(torrent_id)
+            hash_dict = {}
+
+        return hash_dict
 
     def torrent_select_all(self, torrent_id):
-        torr_info = self.torrent_info(torrent_id)
-        file_string = ''
-        for i in torr_info['files']:
-            res = [ele for ele in self.common_video_extensions() if(ele in os.path.splitext(i['path'])[1])]
-            if res and ('Sample' in i['path'] or 'sample.' in i['path']) == False:
-                if file_string == '':
-                    file_string = file_string + str(i['id'])
-                else:
-                    file_string = file_string + ',' + str(i['id'])
-        file_id='all'
-        response = self.torrent_select(torrent_id,file_string)
-        return response
+        try:
+            torrent_info = self.torrent_info(torrent_id)
+            files = torrent_info.get('files', [])
+            
+            valid_file_ids = [
+                str(file['id']) for file in files
+                if 'sample' not in file['path'].lower() 
+                and source_utils.is_file_ext_valid(file['path'])
+            ]
+
+            if valid_file_ids:
+                file_string = ','.join(valid_file_ids)
+                return self.torrent_select(torrent_id, file_string)
+            
+            return self.torrent_select(torrent_id, 'all')
+
+        except Exception as e:
+            g.log(f"Error selecting files for torrent {torrent_id}: {e}", "error")
+            return None
 
     def add_magnet(self, magnet):
         post_data = {"magnet": magnet}
@@ -332,14 +318,6 @@ class RealDebrid:
     def delete_torrent(self, id):
         url = f"torrents/delete/{id}"
         self.delete_url(url)
-
-    def common_video_extensions(self):
-        getSupportedMedia = '.m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.xspf|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.mpl|.webm|.bdmv|.bdm|.wtv|.trp|.f4v|.ssif|.pvr|.disc|'
-        return [
-            i
-            for i in getSupportedMedia.split("|")
-            if i not in ["", ".zip", ".rar"]
-        ]
 
     @staticmethod
     def is_streamable_storage_type(storage_variant):

--- a/resources/lib/gui/windows/resolver_window.py
+++ b/resources/lib/gui/windows/resolver_window.py
@@ -47,7 +47,6 @@ class ResolverWindow(SingleItemWindow):
             except Exception:
                 g.log_stacktrace()
                 continue
-        # import web_pdb; web_pdb.set_trace()
         if stream_link is None:
             self.return_data = "none", "none"
         else:

--- a/resources/lib/gui/windows/resolver_window.py
+++ b/resources/lib/gui/windows/resolver_window.py
@@ -47,7 +47,11 @@ class ResolverWindow(SingleItemWindow):
             except Exception:
                 g.log_stacktrace()
                 continue
-        self.return_data = stream_link, release_title
+        # import web_pdb; web_pdb.set_trace()
+        if stream_link is None:
+            self.return_data = "none", "none"
+        else:
+            self.return_data = stream_link, release_title
 
     def get_return_data(self):
         return (None, None) if self.canceled else self.return_data

--- a/resources/lib/gui/windows/smartplay_window.py
+++ b/resources/lib/gui/windows/smartplay_window.py
@@ -142,5 +142,5 @@ class SmartPlayWindow(BaseWindow):
             if control_id == 3002:
                 self.close()
             if control_id == 3003:
-                self.player.stop()
+                xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
                 self.close()

--- a/resources/lib/gui/windows/smartplay_window.py
+++ b/resources/lib/gui/windows/smartplay_window.py
@@ -142,5 +142,5 @@ class SmartPlayWindow(BaseWindow):
             if control_id == 3002:
                 self.close()
             if control_id == 3003:
-                xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
+                g.PLAYLIST.clear()
                 self.close()

--- a/resources/lib/gui/windows/source_select.py
+++ b/resources/lib/gui/windows/source_select.py
@@ -83,7 +83,7 @@ class SourceSelect(SourceWindow):
             overwrite_cache=pack_select,
         )
 
-        if self.stream_link is None:
+        if self.stream_link is None or self.stream_link == "none":
             self.setProperty("resolving", "false")
             resolver_helper.close_window()
             g.notification(g.ADDON_NAME, g.get_language_string(30032), time=2000)

--- a/resources/lib/modules/download_manager.py
+++ b/resources/lib/modules/download_manager.py
@@ -499,10 +499,7 @@ class _RealDebridDownloader(_DebridDownloadBase):
         self.available_files = []
 
     def _fetch_available_files(self):
-        availability = self.debrid_module.check_hash(self.source["hash"])
-        availability = [
-            i for i in availability[self.source["hash"]]["rd"] if self.debrid_module.is_streamable_storage_type(i)
-        ]
+        availability = self.debrid_module.check_hash(self.source["hash"])[self.source["hash"]]["rd"]
         try:
             availability = sorted(availability, key=lambda k: len(k.values()))[0]
         except IndexError as e:

--- a/resources/lib/modules/download_manager.py
+++ b/resources/lib/modules/download_manager.py
@@ -497,15 +497,21 @@ class _RealDebridDownloader(_DebridDownloadBase):
         super().__init__(source)
         self.debrid_module = RealDebrid()
         self.available_files = []
+        self.torrent_info = []
 
     def _fetch_available_files(self):
-        availability = self.debrid_module.check_hash(self.source["hash"])[self.source["hash"]]["rd"]
         try:
-            availability = sorted(availability, key=lambda k: len(k.values()))[0]
-        except IndexError as e:
+            availability = self.debrid_module.check_hash(self.source["hash"])[self.source["hash"]]
+            self.torrent_info = availability["torrent_info"]
+            availability = sorted(availability["rd"], key=lambda k: len(k.values()))
+        except Exception as e:
             raise SourceNotAvailable from e
+        self.available_files = [
+            {"path": value["filename"], "index": key} 
+            for rd_item in availability
+            for key, value in rd_item.items()
+        ]
 
-        self.available_files = [{"path": value["filename"], "index": key} for key, value in availability.items()]
         return self.available_files
 
     def _resolve_file_url(self, file):
@@ -514,10 +520,8 @@ class _RealDebridDownloader(_DebridDownloadBase):
     def _resolver_setup(self, selected_files):
         if self.source.get("type") in ["hoster", "cloud"]:
             return [(self.source.get("url", ""), self.source.get("release_tile"))]
-
-        torrent_id = self.debrid_module.add_magnet(self.source["magnet"])["id"]
-        self.debrid_module.torrent_select(torrent_id, ",".join([i["index"] for i in self.available_files]))
-        info = self.debrid_module.torrent_info(torrent_id)
+        
+        info = self.torrent_info
         remote_files = {str(i["id"]): idx for idx, i in enumerate(info["files"])}
         selected_files = [(remote_files[i[0]["index"]], i[1]) for i in selected_files]
         return [(info["links"][i[0]], i[1]) for i in selected_files]
@@ -590,7 +594,6 @@ def create_task(source):
     :param source: dict
     :return: None
     """
-
     if (source_type := source.get("type")) not in VALID_SOURCE_TYPES:
         raise InvalidSourceType(source_type)
 

--- a/resources/lib/modules/getSources.py
+++ b/resources/lib/modules/getSources.py
@@ -1143,23 +1143,14 @@ class TorrentCacheCheck:
         self.threads.wait_completion()
 
     def _all_debrid_worker(self, torrent_list):
-
         try:
-            api = all_debrid.AllDebrid()
-
             if len(torrent_list) == 0:
                 return
-
-            cache_check = api.check_hash([i['hash'] for i in torrent_list])
-
-            if not cache_check:
-                return
-
-            for idx, i in enumerate(torrent_list):
+            
+            for i in torrent_list:
                 try:
-                    if cache_check['magnets'][idx]['instant'] is True:
-                        i['debrid_provider'] = 'all_debrid'
-                        self.store_torrent(i)
+                    i['debrid_provider'] = 'all_debrid'
+                    self.store_torrent(i)
                 except KeyError:
                     g.log(
                         "KeyError in AllDebrid Cache check worker. "

--- a/resources/lib/modules/getSources.py
+++ b/resources/lib/modules/getSources.py
@@ -1171,7 +1171,6 @@ class TorrentCacheCheck:
             g.log_stacktrace()
 
     def _realdebrid_worker(self, torrent_list, info):
-
         try:
             for i in torrent_list:
                 with contextlib.suppress(KeyError):

--- a/resources/lib/modules/getSources.py
+++ b/resources/lib/modules/getSources.py
@@ -1173,19 +1173,10 @@ class TorrentCacheCheck:
     def _realdebrid_worker(self, torrent_list, info):
 
         try:
-            hash_list = [i['hash'] for i in torrent_list]
-            api = real_debrid.RealDebrid()
-            real_debrid_cache = api.check_hash(hash_list)
-
             for i in torrent_list:
                 with contextlib.suppress(KeyError):
-                    if 'rd' not in real_debrid_cache.get(i['hash'], {}):
-                        continue
-                    if len(real_debrid_cache[i['hash']]['rd']) >= 1:
-                        if self.scraper_class.media_type == 'episode':
-                            self._handle_episode_rd_worker(i, real_debrid_cache, info)
-                        else:
-                            self._handle_movie_rd_worker(i, real_debrid_cache)
+                    i['debrid_provider'] = 'real_debrid'
+                    self.store_torrent(i)
         except Exception:
             g.log_stacktrace()
 
@@ -1244,6 +1235,10 @@ class SourceWindowAdapter:
     def create(self):
         if self.silent:
             return
+        if self.display_style == 2:
+            self.background_dialog = xbmcgui.DialogProgressBG()
+            self.background_dialog.create("Loading","")
+            g.close_busy_dialog()
         if self.display_style == 1:
             # this one is deleted in `close()`
             self.background_dialog = xbmcgui.DialogProgressBG()
@@ -1278,13 +1273,15 @@ class SourceWindowAdapter:
             self.dialog.setProperty("runtime", str(f"{round(runtime, 2)} {g.get_language_string(30554)}"))
         elif self.display_style == 1 and self.background_dialog:
             self.background_dialog.update(progress, message=text)
+        elif self.display_style == 2 and self.background_dialog:
+            self.background_dialog.update(progress)
 
     def set_property(self, key, value):
         if self.silent:
             return
         if self.display_style == 0 and self.dialog:
             self.dialog.setProperty(key, str(value))
-        elif self.display_style == 1:
+        elif self.display_style == 1 or self.display_style == 2:
             return
 
     def set_progress(self, progress):
@@ -1292,7 +1289,7 @@ class SourceWindowAdapter:
             return
         if self.display_style == 0 and self.dialog:
             self.dialog.setProgress(progress)
-        elif self.display_style == 1 and self.background_dialog:
+        elif (self.display_style == 1 or self.display_style == 2) and self.background_dialog:
             self.background_dialog.update(progress)
 
     def close(self):
@@ -1301,6 +1298,6 @@ class SourceWindowAdapter:
         if self.display_style == 0 and self.dialog:
             self.dialog.close()
             del self.dialog
-        elif self.display_style == 1 and self.background_dialog:
+        elif (self.display_style == 1 or self.display_style == 2) and self.background_dialog:
             self.background_dialog.close()
             del self.background_dialog

--- a/resources/lib/modules/globals.py
+++ b/resources/lib/modules/globals.py
@@ -1144,7 +1144,7 @@ class GlobalVariables:
 
     @cached_property
     def common_video_extensions(self):
-        return tuple({ext for ext in xbmc.getSupportedMedia("video").split("|") if ext not in {"", ".zip", ".rar"}})
+        return tuple({ext for ext in xbmc.getSupportedMedia("video").split("|") if ext not in {"", ".zip", ".rar", ".url"}})
 
     def add_directory_item(self, name, **params):
         menu_item = params.pop("menu_item", {})

--- a/resources/lib/modules/helpers.py
+++ b/resources/lib/modules/helpers.py
@@ -31,7 +31,7 @@ class Resolverhelper:
         stream_link = None
         release_title = None
 
-        if g.get_bool_runtime_setting('tempSilent'):
+        if g.get_bool_runtime_setting('tempSilent') or g.get_bool_setting("general.resolverHide", False):
             stream_link, release_title = Resolver().resolve_multiple_until_valid_link(
                 sources, item_information, pack_select, True
             )

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -102,6 +102,8 @@ class SerenPlayer(xbmc.Player):
         self._handle_bookmark()
         self._add_support_for_external_trakt_scrobbling()
 
+        self.playing_next_time = max(self.playing_next_time, self.item_information["info"]["duration"] * (1 - (g.get_int_setting("playingnext.percent") / 100)))
+
         xbmcplugin.setResolvedUrl(g.PLUGIN_HANDLE, True, self._create_list_item(stream_link))
 
         self._keep_alive()

--- a/resources/lib/modules/resolver/__init__.py
+++ b/resources/lib/modules/resolver/__init__.py
@@ -207,7 +207,6 @@ class Resolver:
                 return None
             except Exception as e:
                 g.log(f"Failing Magnet: {source['magnet']}")
-                raise ResolverFailure(source) from e
         elif source["type"] in ["hoster", "cloud"]:
             try:
                 stream_link = api.resolve_stream_url({"link": source["url"]})

--- a/resources/lib/modules/resolver/torrent_resolvers/all_debrid.py
+++ b/resources/lib/modules/resolver/torrent_resolvers/all_debrid.py
@@ -1,5 +1,5 @@
 from resources.lib.debrid.all_debrid import AllDebrid
-from resources.lib.modules.exceptions import UnexpectedResponse
+from resources.lib.modules.exceptions import GeneralCachingFailure
 from resources.lib.modules.globals import g
 from resources.lib.modules.resolver.torrent_resolvers.base_resolver import (
     TorrentResolverBase,
@@ -26,7 +26,8 @@ class AllDebridResolver(TorrentResolverBase):
         self.magnet_id = self.debrid_module.upload_magnet(torrent['hash'])["magnets"][0]["id"]
         status = self.debrid_module.magnet_status(self.magnet_id)["magnets"]
         if status["status"] != "Ready":
-            raise UnexpectedResponse(status)
+            self.debrid_module.delete_magnet(self.magnet_id)
+            raise GeneralCachingFailure(status)
         return status['links']
 
     def resolve_stream_url(self, file_info):

--- a/resources/lib/modules/resolver/torrent_resolvers/real_debrid.py
+++ b/resources/lib/modules/resolver/torrent_resolvers/real_debrid.py
@@ -15,6 +15,7 @@ class RealDebridResolver(TorrentResolverBase):
     def __init__(self):
         super().__init__()
         self.debrid_module = RealDebrid()
+        self.torrent_id = None
         self._source_normalization = (
             ("path", "path", None),
             ("bytes", "size", lambda k: (k / 1024) / 1024),
@@ -24,24 +25,16 @@ class RealDebridResolver(TorrentResolverBase):
             ("link", "link", None),
             ("selected", "selected", None),
         )
-        self.torrent_id = None
 
-    def _get_files_from_check_hash(self, torrent, item_information):
-        hash_check = self.debrid_module.check_hash(torrent["hash"])[torrent["hash"]]
-        [value.update({"idx": key}) for sub_dict in hash_check["rd"] for key, value in sub_dict.items()]
-        return hash_check
-
-    def _get_selected_files(self, torrent_id):
-        info = self.debrid_module.torrent_info(torrent_id)
-        files = [i for i in info["files"] if i["selected"]]
-        [i.update({"link": info["links"][idx]}) for idx, i in enumerate(files)]
-        if g.get_bool_setting("rd.autodelete"):
-            self.debrid_module.delete_torrent(info["id"])
+    def _get_selected_files(self, torrent_info):
+        files = [i for i in torrent_info["files"] if i["selected"]]
+        [i.update({"link": torrent_info["links"][idx]}) for idx, i in enumerate(files)]
         return files
 
     def _fetch_source_files(self, torrent, item_information):
-        hash_check = self._get_files_from_check_hash(torrent, item_information)
-        return self._get_selected_files(hash_check["torrent_id"])
+        hash_check = self.debrid_module.check_hash(torrent["hash"])[torrent["hash"]]
+        self.torrent_id = hash_check["torrent_id"]
+        return self._get_selected_files(hash_check["torrent_info"])
 
     def resolve_stream_url(self, file_info):
         """

--- a/resources/lib/modules/resolver/torrent_resolvers/real_debrid.py
+++ b/resources/lib/modules/resolver/torrent_resolvers/real_debrid.py
@@ -27,34 +27,21 @@ class RealDebridResolver(TorrentResolverBase):
         self.torrent_id = None
 
     def _get_files_from_check_hash(self, torrent, item_information):
-        hash_check = self.debrid_module.check_hash(torrent["hash"])[torrent["hash"]]["rd"]
-        try:
-            hash_check = [
-                storage_variant
-                for storage_variant in hash_check
-                if self.debrid_module.is_streamable_storage_type(storage_variant)
-            ]
-        except IndexError as e:
-            raise FileIdentification(hash_check) from e
-        if self.media_type == "episode":
-            hash_check = [i for i in hash_check if get_best_episode_match("filename", i.values(), item_information)][0]
-        else:
-            hash_check = hash_check[0]
-        [value.update({"idx": key}) for key, value in hash_check.items()]
-        return hash_check.values()
+        hash_check = self.debrid_module.check_hash(torrent["hash"])[torrent["hash"]]
+        [value.update({"idx": key}) for sub_dict in hash_check["rd"] for key, value in sub_dict.items()]
+        return hash_check
 
     def _get_selected_files(self, torrent_id):
         info = self.debrid_module.torrent_info(torrent_id)
         files = [i for i in info["files"] if i["selected"]]
         [i.update({"link": info["links"][idx]}) for idx, i in enumerate(files)]
+        if g.get_bool_setting("rd.autodelete"):
+            self.debrid_module.delete_torrent(info["id"])
         return files
 
     def _fetch_source_files(self, torrent, item_information):
         hash_check = self._get_files_from_check_hash(torrent, item_information)
-        cached_torrent = self.debrid_module.add_magnet(torrent["magnet"])
-        self.debrid_module.torrent_select(cached_torrent["id"], ",".join([i["idx"] for i in hash_check]))
-        self.torrent_id = cached_torrent["id"]
-        return self._get_selected_files(self.torrent_id)
+        return self._get_selected_files(hash_check["torrent_id"])
 
     def resolve_stream_url(self, file_info):
         """
@@ -65,5 +52,5 @@ class RealDebridResolver(TorrentResolverBase):
         return self.debrid_module.resolve_hoster(file_info["link"])
 
     def _do_post_processing(self, item_information, torrent, identified_file):
-        if g.get_bool_setting("rd.autodelete") or identified_file is None:
+        if identified_file is None and not g.get_bool_setting("rd.autodelete"):
             self.debrid_module.delete_torrent(self.torrent_id)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1228,9 +1228,15 @@
 						<options>
 							<option label="30175">0</option>
 							<option label="30176">1</option>
+							<option label="30652">2</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
+				</setting>
+				<setting id="general.resolverHide"  type="boolean" label="30650" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
 				</setting>
 				<setting id="general.torrentCache" type="boolean" label="30111" help="">
 					<level>0</level>
@@ -1476,10 +1482,17 @@
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
-				<setting id="general.enablesizelimit" type="boolean" label="30118" help="">
+				<setting id="general.enablesizelimit" type="integer" label="30118" help="">
 					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
+					<default>0</default>
+						<constraints>
+						<options>
+							<option label="30648">0</option>
+							<option label="30645">1</option>
+							<option label="30647">2</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
 				</setting>
 				<setting id="general.sizelimit.movie" type="integer" label="30192" help="" parent="general.enablesizelimit">
 					<level>0</level>
@@ -1491,7 +1504,7 @@
 					</constraints>
 					<dependencies>
 						<dependency type="visible">
-							<condition operator="is" setting="general.enablesizelimit">true</condition>
+							<condition operator="is" setting="general.enablesizelimit">2</condition>
 						</dependency>
 					</dependencies>
 					<control type="slider" format="integer">
@@ -1508,7 +1521,7 @@
 					</constraints>
 					<dependencies>
 						<dependency type="visible">
-							<condition operator="is" setting="general.enablesizelimit">true</condition>
+							<condition operator="is" setting="general.enablesizelimit">2</condition>
 						</dependency>
 					</dependencies>
 					<control type="slider" format="integer">
@@ -1525,7 +1538,7 @@
 					</constraints>
 					<dependencies>
 						<dependency type="visible">
-							<condition operator="is" setting="general.enablesizelimit">true</condition>
+							<condition operator="is" setting="general.enablesizelimit">2</condition>
 						</dependency>
 					</dependencies>
 					<control type="slider" format="number">
@@ -1542,12 +1555,46 @@
 					</constraints>
 					<dependencies>
 						<dependency type="visible">
-							<condition operator="is" setting="general.enablesizelimit">true</condition>
+							<condition operator="is" setting="general.enablesizelimit">2</condition>
 						</dependency>
 					</dependencies>
 					<control type="slider" format="number">
 						<popup>false</popup>
 					</control>
+				</setting>
+				<setting id="general.speedlimit" type="number" label="30646" help="" parent="general.enablesizelimit">
+					<level>0</level>
+					<default>10</default>
+					<constraints>
+						<minimum>0.0</minimum>
+						<step>0.5</step>
+						<maximum>300</maximum>
+					</constraints>
+					<control type="slider" format="number">
+						<popup>false</popup>
+					</control>
+					<dependencies>
+						<dependency type="visible">
+							<condition operator="is" setting="general.enablesizelimit">1</condition>
+						</dependency>
+					</dependencies>
+				</setting>
+				<setting id="general.speedminimum" type="number" label="30649" help="" parent="general.enablesizelimit">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<minimum>0.0</minimum>
+						<step>0.5</step>
+						<maximum>300</maximum>
+					</constraints>
+					<control type="slider" format="number">
+						<popup>false</popup>
+					</control>
+					<dependencies>
+						<dependency type="visible">
+							<condition operator="is" setting="general.enablesizelimit">1</condition>
+						</dependency>
+					</dependencies>
 				</setting>
 				<setting id="general.filters" type="string" help="">
 					<level>4</level>
@@ -2003,6 +2050,27 @@
 						</dependency>
 					</dependencies>
 					<control type="toggle"/>
+				</setting>
+				<setting id="playingnext.percent" type="integer" label="30651" help="" parent="smartplay.playingnextdialog">
+					<level>0</level>
+					<default>95</default>
+					<constraints>
+						<minimum>0</minimum>
+						<step>1</step>
+						<maximum>100</maximum>
+					</constraints>
+					<dependencies>
+						<dependency type="visible">
+							<and>
+								<condition operator="is" setting="smartplay.playlistcreate">true</condition>
+								<condition operator="is" setting="smartplay.playingnextdialog">true</condition>
+								<condition operator="is" setting="smartplay.displaystyle">0</condition>
+							</and>
+						</dependency>
+					</dependencies>
+					<control type="slider" format="percentage">
+						<popup>false</popup>
+					</control>
 				</setting>
 				<setting id="playingnext.time" type="integer" label="30105" help="" parent="smartplay.playingnextdialog">
 					<level>0</level>

--- a/resources/skins/Default/1080i/playing_next.xml
+++ b/resources/skins/Default/1080i/playing_next.xml
@@ -165,6 +165,22 @@
 						<texturenofocus border="10" colordiffuse="99000000">white.png</texturenofocus>
 						<pulseonselect>no</pulseonselect>
 					</control>
+					
+					<!-- Cancel -->
+					<control type="button" id="3003">
+						<label>$ADDON[plugin.video.seren 30070]</label>
+						<height>56</height>
+						<width>auto</width>
+						<font>font12</font>
+						<textoffsetx>20</textoffsetx>
+						<textcolor>ddffffff</textcolor>
+						<focusedcolor>eeffffff</focusedcolor>
+						<selectedcolor>ddffffff</selectedcolor>
+						<align>center</align>
+						<texturefocus border="10" colordiffuse="$INFO[Window.Property(settings.color)]">white.png</texturefocus>
+						<texturenofocus border="10" colordiffuse="99000000">white.png</texturenofocus>
+						<pulseonselect>no</pulseonselect>
+					</control>
 				</control>
 			</control>
         </control>


### PR DESCRIPTION
Apologies, this is my second time creating this pull request. Created it earlier, but in my attempt to clean up the messy commit history ended up breaking it, so i recreated the fork.

Changes:

- Version bump to 3.0.5
- Included RD fix by [henryjfry](https://github.com/henryjfry) (modified to only check if hash is cached when attempting to play source, similar to [Tikipeter](https://github.com/Tikipeter) implementation, resulting in much faster scrape times and reduced RD API calls)
- Added option to filter results by internet speed instead of just file size
- Added 'Minimum Percentage Left Before Showing Dialog option' for smartplay window. Whichever one occurs first (percent or time remaining) will be used to dictate when the window will be shown
- Added 'Cancel' button to smartplay window
- Added option to hide resolver window when attempting to play
- Added 'Icon Only' scraper display style option for a more minimalistic background scrape
- Improved 3D filtering and added 60 FPS filter